### PR TITLE
Super peer timed handler

### DIFF
--- a/peer/handler/TimedResponseHandler.py
+++ b/peer/handler/TimedResponseHandler.py
@@ -14,12 +14,6 @@ class TimedResponseHandler(HandlerInterface):
 		:param sd: the socket descriptor used for read the request
 		:return None
 		"""
-		try:
-			command = sd.recv(4).decode()
-		except OSError as e:
-			shell.print_red(f'\nUnable to read the command from the socket: {e}\n')
-			sd.close()
-			return
 
 		try:
 			response = sd.recv(300).decode()
@@ -29,16 +23,18 @@ class TimedResponseHandler(HandlerInterface):
 			return
 		sd.close()
 
+		command = response[0:4]
+
 		if command == "ASUP":
 
-			if len(response) != 76:
+			if len(response) != 80:
 				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: ASUP<pkt_id><ip_peer><port_peer>")
 				return
 
-			pktid = response[0:16]
-			ip_peer = response[16:71]
+			pktid = response[4:20]
+			ip_peer = response[20:75]
 			ip4_peer, ip6_peer = net_utils.get_ip_pair(ip_peer)
-			port_peer = int(response[71:76])
+			port_peer = int(response[75:80])
 
 			if pktid != LocalData.get_sent_packet():
 				return

--- a/peer/handler/TimedResponseHandler.py
+++ b/peer/handler/TimedResponseHandler.py
@@ -25,7 +25,6 @@ class TimedResponseHandler(HandlerInterface):
 			response = sd.recv(300).decode()
 		except socket.error as e:
 			shell.print_red(f'Unable to read the response from the socket: {e}\n')
-			shell.print_red(f"\nInvalid response: {command} -> {response}\n")
 			sd.close()
 			return
 		sd.close()
@@ -47,8 +46,6 @@ class TimedResponseHandler(HandlerInterface):
 			LocalData.add_superpeer_candidate(ip4_peer, ip6_peer, port_peer)
 
 		else:
-			wrong_response = sd.recv(300).decode()
-			sd.close()
-			shell.print_red(f"\nInvalid response: {command} -> {wrong_response}\n")
+			shell.print_red(f"\nInvalid response: {command} -> {response}\n")
 
 		return

--- a/peer/handler/TimedResponseHandler.py
+++ b/peer/handler/TimedResponseHandler.py
@@ -21,14 +21,16 @@ class TimedResponseHandler(HandlerInterface):
 			sd.close()
 			return
 
-		if command == "ASUP":
-			try:
-				response = sd.recv(300).decode()
-			except socket.error as e:
-				shell.print_red(f'Unable to read the {command} response from the socket: {e}\n')
-				sd.close()
-				return
+		try:
+			response = sd.recv(300).decode()
+		except socket.error as e:
+			shell.print_red(f'Unable to read the response from the socket: {e}\n')
+			shell.print_red(f"\nInvalid response: {command} -> {response}\n")
 			sd.close()
+			return
+		sd.close()
+
+		if command == "ASUP":
 
 			if len(response) != 76:
 				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: ASUP<pkt_id><ip_peer><port_peer>")

--- a/superpeer/LocalData.py
+++ b/superpeer/LocalData.py
@@ -13,6 +13,9 @@ class LocalData:
 	# 'pktid'
 	sent_packet = str()
 
+	# ('ipv4', 'ipv6', 'port', 'md5', 'filename')
+	peer_files = list()
+
 	# super_super_friends management --------------------------------------------------------
 	@classmethod
 	def is_super_friend(cls, ip4_peer: str, ip6_peer: str, port_peer: int) -> bool:
@@ -84,3 +87,49 @@ class LocalData:
 	def get_sent_packet(cls) -> str:
 		return cls.sent_packet
 	# -----------------------------------------------------------------------------
+
+	# peer_files management--------------------------------------------------------
+	@classmethod
+	def get_peer_files(cls) -> list:
+		return cls.peer_files
+
+	@classmethod
+	def get_file_owner_ip4(cls, file: tuple) -> str:
+		return file[0]
+
+	@classmethod
+	def get_file_owner_ip6(cls, file: tuple) -> str:
+		return file[1]
+
+	@classmethod
+	def get_file_owner_port(cls, file: tuple) -> int:
+		return file[2]
+
+	@classmethod
+	def get_file_md5(cls, file: tuple) -> str:
+		return file[3]
+
+	@classmethod
+	def get_file_name(cls, file: tuple) -> str:
+		return file[4]
+
+	@classmethod
+	def add_peer_files(cls, ip4_peer: str, ip6_peer: str, port_peer: int, filemd5: str, filename: str) -> None:
+		cls.peer_files.append((ip4_peer, ip6_peer, port_peer, filemd5, filename))
+
+	@classmethod
+	def exist_peer_files(cls, ip4_peer: str, ip6_peer: str, port_peer: int, filemd5: str, filename: str) -> bool:
+		return (ip4_peer, ip6_peer, port_peer, filemd5, filename) in cls.peer_files
+
+	@classmethod
+	def peer_file_index(cls, ip4_peer: str, ip6_peer: str, port_peer: int, filemd5: str, filename: str) -> int:
+		return cls.peer_files.index((ip4_peer, ip6_peer, port_peer, filemd5, filename))
+
+	@classmethod
+	def get_peer_file_by_index(cls, index: int) -> tuple:
+		return cls.peer_files.pop(index)
+
+	@classmethod
+	def clear_peer_files(cls) -> None:
+		cls.peer_files.clear()
+# -----------------------------------------------------------------------------

--- a/superpeer/handler/TimedResponseHandler.py
+++ b/superpeer/handler/TimedResponseHandler.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 import socket
-from utils import shell_colors
+from utils import net_utils, shell_colors as shell
 from common.HandlerInterface import HandlerInterface
+from superpeer.LocalData import LocalData
 
 
 class TimedResponseHandler(HandlerInterface):
@@ -16,19 +17,65 @@ class TimedResponseHandler(HandlerInterface):
 		try:
 			command = sd.recv(4).decode()
 		except OSError as e:
-			shell_colors.print_red(f'\nUnable to read the command from the socket: {e}\n')
+			shell.print_red(f'\nUnable to read the command from the socket: {e}\n')
 			sd.close()
 			return
 
 		if command == "AQUE":
-			pass
+			try:
+				response = sd.recv(300).decode()
+			except socket.error as e:
+				shell.print_red(f'Unable to read the {command} response from the socket: {e}\n')
+				sd.close()
+				return
+			sd.close()
+
+			if len(response) != 212:
+				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: AQUE<pkt_id><ip_peer><port_peer><file_md5><filename>")
+				return
+
+			pktid = response[0:16]
+			ip_peer = response[16:71]
+			ip4_peer, ip6_peer = net_utils.get_ip_pair(ip_peer)
+			port_peer = int(response[71:76])
+			file_md5 = response[76:108]
+			filename = response[108:208]
+
+			if pktid != LocalData.get_sent_packet():
+				return
+
+			if not LocalData.exist_peer_files(ip4_peer, ip6_peer, port_peer, file_md5, filename):
+				LocalData.add_peer_files(ip4_peer, ip6_peer, port_peer, file_md5, filename)
 
 		elif command == "ASUP":
-			pass
+			try:
+				response = sd.recv(300).decode()
+			except socket.error as e:
+				shell.print_red(f'Unable to read the {command} response from the socket: {e}\n')
+				sd.close()
+				return
+			sd.close()
+
+			if len(response) != 76:
+				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: ASUP<pkt_id><ip_peer><port_peer>")
+				return
+
+			pktid = response[0:16]
+			ip_peer = response[16:71]
+			ip4_peer, ip6_peer = net_utils.get_ip_pair(ip_peer)
+			port_peer = int(response[71:76])
+
+			if pktid != LocalData.get_sent_packet():
+				return
+
+			if not LocalData.is_super_friend(ip4_peer, ip6_peer, port_peer):
+				LocalData.add_super_friend(ip4_peer, ip6_peer, port_peer)
+				shell.print_green('New superfriend found: ', end='')
+				print(f'{ip4_peer}|{ip6_peer} [{port_peer}]')
 
 		else:
 			wrong_response = sd.recv(300).decode()
 			sd.close()
-			shell_colors.print_red(f"\nInvalid response: {command} -> {wrong_response}\n")
+			shell.print_red(f"\nInvalid response: {command} -> {wrong_response}\n")
 
 		return

--- a/superpeer/handler/TimedResponseHandler.py
+++ b/superpeer/handler/TimedResponseHandler.py
@@ -21,14 +21,16 @@ class TimedResponseHandler(HandlerInterface):
 			sd.close()
 			return
 
-		if command == "AQUE":
-			try:
-				response = sd.recv(300).decode()
-			except socket.error as e:
-				shell.print_red(f'Unable to read the {command} response from the socket: {e}\n')
-				sd.close()
-				return
+		try:
+			response = sd.recv(300).decode()
+		except socket.error as e:
+			shell.print_red(f'Unable to read the response from the socket: {e}\n')
+			shell.print_red(f"\nInvalid response: {command} -> {response}\n")
 			sd.close()
+			return
+		sd.close()
+
+		if command == "AQUE":
 
 			if len(response) != 212:
 				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: AQUE<pkt_id><ip_peer><port_peer><file_md5><filename>")
@@ -48,13 +50,6 @@ class TimedResponseHandler(HandlerInterface):
 				LocalData.add_peer_files(ip4_peer, ip6_peer, port_peer, file_md5, filename)
 
 		elif command == "ASUP":
-			try:
-				response = sd.recv(300).decode()
-			except socket.error as e:
-				shell.print_red(f'Unable to read the {command} response from the socket: {e}\n')
-				sd.close()
-				return
-			sd.close()
 
 			if len(response) != 76:
 				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: ASUP<pkt_id><ip_peer><port_peer>")

--- a/superpeer/handler/TimedResponseHandler.py
+++ b/superpeer/handler/TimedResponseHandler.py
@@ -25,7 +25,6 @@ class TimedResponseHandler(HandlerInterface):
 			response = sd.recv(300).decode()
 		except socket.error as e:
 			shell.print_red(f'Unable to read the response from the socket: {e}\n')
-			shell.print_red(f"\nInvalid response: {command} -> {response}\n")
 			sd.close()
 			return
 		sd.close()
@@ -69,8 +68,6 @@ class TimedResponseHandler(HandlerInterface):
 				print(f'{ip4_peer}|{ip6_peer} [{port_peer}]')
 
 		else:
-			wrong_response = sd.recv(300).decode()
-			sd.close()
-			shell.print_red(f"\nInvalid response: {command} -> {wrong_response}\n")
+			shell.print_red(f"\nInvalid response: {command} -> {response}\n")
 
 		return

--- a/superpeer/handler/TimedResponseHandler.py
+++ b/superpeer/handler/TimedResponseHandler.py
@@ -14,12 +14,6 @@ class TimedResponseHandler(HandlerInterface):
 		:param sd: the socket descriptor used for read the request
 		:return None
 		"""
-		try:
-			command = sd.recv(4).decode()
-		except OSError as e:
-			shell.print_red(f'\nUnable to read the command from the socket: {e}\n')
-			sd.close()
-			return
 
 		try:
 			response = sd.recv(300).decode()
@@ -29,18 +23,20 @@ class TimedResponseHandler(HandlerInterface):
 			return
 		sd.close()
 
+		command = response[0:4]
+
 		if command == "AQUE":
 
 			if len(response) != 212:
 				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: AQUE<pkt_id><ip_peer><port_peer><file_md5><filename>")
 				return
 
-			pktid = response[0:16]
-			ip_peer = response[16:71]
+			pktid = response[4:20]
+			ip_peer = response[20:75]
 			ip4_peer, ip6_peer = net_utils.get_ip_pair(ip_peer)
-			port_peer = int(response[71:76])
-			file_md5 = response[76:108]
-			filename = response[108:208]
+			port_peer = int(response[75:80])
+			file_md5 = response[80:112]
+			filename = response[112:212]
 
 			if pktid != LocalData.get_sent_packet():
 				return
@@ -50,14 +46,14 @@ class TimedResponseHandler(HandlerInterface):
 
 		elif command == "ASUP":
 
-			if len(response) != 76:
+			if len(response) != 80:
 				shell.print_red(f"Invalid response: : {command} -> {response}. Expected: ASUP<pkt_id><ip_peer><port_peer>")
 				return
 
-			pktid = response[0:16]
-			ip_peer = response[16:71]
+			pktid = response[4:20]
+			ip_peer = response[20:75]
 			ip4_peer, ip6_peer = net_utils.get_ip_pair(ip_peer)
-			port_peer = int(response[71:76])
+			port_peer = int(response[75:80])
 
 			if pktid != LocalData.get_sent_packet():
 				return


### PR DESCRIPTION
Versione Base del TimedRequestHandler (TRH) per il Superpeer.

Viene chiamato dal MenuHandler (MH) del Superpeer per gestire diversi comportamenti:

1)quando l'utente effettua una ricerca file, il MH lancia nella Superpeer Network una QUER
       --> **TRH attende 20s le varie AQUE e le colleziona in una stuttura dati (peer_files)**
              -->poi il MH deve dare all'utente la possibilità di scaricare

2)quando da un peer arriva una FIND, il MH costruisce una QUER
       -->**TRH  attende 20s le varie AQUE e le colleziona in una stuttura dati (peer_files)**
              -->poi il MH deve dare costruire la AFIN per il peer

3)quando l'utente effettua una ricerca di vicini, il MH lancia nella Superpeer Network una SUPE
       --> **TRH attende 20s le varie ASUP e le colleziona in una stuttura dati (super_friends)
                 e printa una risposta alla volta sul terminale "New superfriend found: ..."**